### PR TITLE
Add initial systemd lifecycle notification support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,9 @@
                  [puppetlabs/kitchensink nil :exclusions [cheshire]]
                  [puppetlabs/i18n]
                  [nrepl/nrepl]
-                 [io.github.clj-kondo/config-slingshot-slingshot "1.0.0"]]
+                 [io.github.clj-kondo/config-slingshot-slingshot "1.0.0"]
+
+                 [com.kohlschutter.junixsocket/junixsocket-core "2.6.1" :extension "pom"]]
 
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                      :username :env/CLOJARS_USERNAME


### PR DESCRIPTION
This adds rudimentary [sd_notify()](https://www.freedesktop.org/software/systemd/man/sd_notify.html) support, and allows service managers to receive a signal when the service is ready.

It could possibly replace the "restart-file" mechanism which seems to serve a similar function, but is somewhat awkward to support.

Issues which might warrant additional work before merging:

- Tests
- Implement watchdog support

