### PR TITLE
Remove scan="true" from logback.xml files that end up inside JARs

### DIFF
--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -1,4 +1,4 @@
-<configuration scan="true">
+<configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>

--- a/examples/java_service/logback.xml
+++ b/examples/java_service/logback.xml
@@ -1,4 +1,4 @@
-<configuration scan="true">
+<configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %-5p [%c{2}] %m%n</pattern>


### PR DESCRIPTION
Some of these files end up inside the package due to leiningen scooping up everything in dev-resources in the :base profile. If they end up being found and used during server startup rather than files on disk (such as during builds and tests), they can't be watched with scan="true" since they are read-only inside the JAR. Logback 1.5 will then log directly to stdout which we don't want. We only need scan="true" for files that get laid down by the openvox-server and openvoxdb packages. To be safe, we are removing scan="true" from all logback.xml files in all repos.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
