### PR TITLE
sd_notify: Add log message

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -95,7 +95,7 @@
             [org.openvoxproject/i18n ~i18n-version]]
 
   :eastwood {:ignored-faults {:reflection {puppetlabs.trapperkeeper.logging [{:line 92}]
-                                           puppetlabs.trapperkeeper.internal [{:line 174}]
+                                           puppetlabs.trapperkeeper.internal [{:line 177}]
                                            puppetlabs.trapperkeeper.testutils.logging true
                                            puppetlabs.trapperkeeper.testutils.logging-test true
                                            puppetlabs.trapperkeeper.services.nrepl.nrepl-service-test true

--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -61,6 +61,9 @@
   "Send a message to systemd NOTIFY_SOCKET if available."
   [^String message]
   (when-let [^String socket-path systemd-notify-socket]
+    (log/info (i18n/trs "Sending sd_notify message to NOTIFY_SOCKET {0}: {1}"
+                        (pr-str socket-path)
+                        (pr-str message)))
     (let [^AFUNIXSocketAddress addr (socket-addr socket-path)]
       (with-open [^AFUNIXDatagramSocket s (AFUNIXDatagramSocket/newInstance)]
         (try


### PR DESCRIPTION
This logs whenever we call sd_notify, the socket path and the actual message we write. This is incredibly helpful when debugging systemd behaviour.

### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->
<!-- For example, `Fixes #12345` -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] read and accepted the [AI Policy](https://github.com/OpenVoxProject/.github/blob/main/AI_POLICY.md) document and added [`Generated-by` or `Assisted-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotations to each of my commits created with the help of an AI agent
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
