### PR TITLE
eastwood: Fix reference to field error can't be resolved.

### DIFF
--- a/src/puppetlabs/trapperkeeper/internal.clj
+++ b/src/puppetlabs/trapperkeeper/internal.clj
@@ -171,7 +171,7 @@
       (if (sequential? (:error data))
         (let [missing-services (keys (ks/filter-map
                                       (fn [_ v] (= v 'missing-required-key))
-                                      (.error (first (:error data)))))]
+                                      (:error (first (:error data)))))]
           (if (= 1 (count missing-services))
             (throw (RuntimeException.
                     (i18n/trs "Service ''{0}'' not found" (first missing-services))))


### PR DESCRIPTION
This popped up in https://github.com/OpenVoxProject/trapperkeeper/pull/88 and I don't know why. I also don't know if this is a valid fix.